### PR TITLE
fix losing parent during rb tree insertion fixup

### DIFF
--- a/Trees/src/main/java/org/intelligentjava/algos/trees/RedBlackTree.java
+++ b/Trees/src/main/java/org/intelligentjava/algos/trees/RedBlackTree.java
@@ -282,6 +282,7 @@ public class RedBlackTree extends AbstractSelfBalancingBinarySearchTree {
                     if (currentNode == parent.right) { // case 2, first rotate left
                         currentNode = parent;
                         rotateLeft(currentNode);
+                        parent = (RedBlackNode) currentNode.parent;
                     }
                     // do not use parent
                     parent.color = ColorEnum.BLACK; // case 3
@@ -305,6 +306,7 @@ public class RedBlackTree extends AbstractSelfBalancingBinarySearchTree {
                     if (currentNode == parent.left) { // case 2, first rotate right
                         currentNode = parent;
                         rotateRight(currentNode);
+                        parent = (RedBlackNode) currentNode.parent;
                     }
                     // do not use parent
                     parent.color = ColorEnum.BLACK; // case 3

--- a/Trees/src/test/java/org/intelligentjava/algos/trees/RedBlackTreeTest.java
+++ b/Trees/src/test/java/org/intelligentjava/algos/trees/RedBlackTreeTest.java
@@ -6,6 +6,9 @@ import org.intelligentjava.algos.trees.RedBlackTree.RedBlackNode;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Tests for Red-Black tree.
  * 
@@ -14,7 +17,17 @@ import org.junit.Test;
  *
  */
 public class RedBlackTreeTest {
-    
+    @Test
+    public void testInsertionFixupColoring() throws Exception {
+        RedBlackTree tree = new RedBlackTree();
+        Node node8 = tree.insert(8);
+        Node node3 = tree.insert(3);
+        Node node4 = tree.insert(4);
+        assertThat(((RedBlackNode)node3).color, equalTo(ColorEnum.RED));
+        assertThat(((RedBlackNode)node4).color, equalTo(ColorEnum.BLACK));
+        assertThat(((RedBlackNode)node8).color, equalTo(ColorEnum.RED));
+    }
+
     @Test
     public void testInsert() {
         RedBlackTree tree = new RedBlackTree();
@@ -33,7 +46,7 @@ public class RedBlackTreeTest {
         Assert.assertEquals(((RedBlackNode)tree.search(8)).color, ColorEnum.RED);
         tree.insert(9); // case 2/3 - rotation right, then left
         Assert.assertEquals(((RedBlackNode)tree.search(10)).color, ColorEnum.RED);
-        Assert.assertEquals(((RedBlackNode)tree.search(8)).color, ColorEnum.BLACK);
+        Assert.assertEquals(((RedBlackNode)tree.search(8)).color, ColorEnum.RED);
         Assert.assertEquals(((RedBlackNode)tree.search(9)).left.value, (Integer)8);
         
         // TODO test other red black tree properties too


### PR DESCRIPTION
* Fixed RedBlackTree#insertRBFixup for tree 8, 3, 4

![img1](https://user-images.githubusercontent.com/9703553/44972614-f4f3e000-af83-11e8-83f1-cef015dbcdf7.png)

* added test RedBlackTreeTest#testInsertionFixupColoring

* Fixed test method RedBlackTreeTest#testInsert for tree 20, 15, 25, 10, 17, 8, 9
![img2](https://user-images.githubusercontent.com/9703553/44972700-4f8d3c00-af84-11e8-8f7b-9fdd140efe79.png)
